### PR TITLE
Fix a silly problem causing an outdated and broken urllib3

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1907,13 +1907,14 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "urllib3"
-version = "1.22"
+version = "1.26.9"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "dev"
 optional = false
-python-versions = "*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 
 [package.extras]
+brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
 secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
@@ -1997,7 +1998,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.9"
-content-hash = "82e247f4bb799141e9177bf26b8a6763830efe12ba2a8277c57dbc77b4e5d80a"
+content-hash = "0a093a11866a875345a25439d3557a27055d4ef78be7ffedbd07072d819ea6cf"
 
 [metadata.files]
 alabaster = [
@@ -3238,8 +3239,8 @@ typing-extensions = [
     {file = "typing_extensions-4.2.0.tar.gz", hash = "sha256:f1c24655a0da0d1b67f07e17a5e6b2a105894e6824b92096378bb3668ef02376"},
 ]
 urllib3 = [
-    {file = "urllib3-1.22-py2.py3-none-any.whl", hash = "sha256:06330f386d6e4b195fbfc736b297f58c5a892e4440e54d294d7004e3a9bbea1b"},
-    {file = "urllib3-1.22.tar.gz", hash = "sha256:cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f"},
+    {file = "urllib3-1.26.9-py2.py3-none-any.whl", hash = "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14"},
+    {file = "urllib3-1.26.9.tar.gz", hash = "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"},
 ]
 virtualenv = [
     {file = "virtualenv-20.14.1-py2.py3-none-any.whl", hash = "sha256:e617f16e25b42eb4f6e74096b9c9e37713cf10bf30168fb4a739f3fa8f898a3a"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ sphinx-click = ">=4.0.3"
 Pygments = ">=2.10.0"
 pyupgrade = ">=2.29.1"
 furo = ">=2021.11.12"
+urllib3 = {python = ">=3.9,<4.0", version = ">=1.26"}
 
 [tool.poetry.scripts]
 whispy = "whispy.__main__:main"


### PR DESCRIPTION
For some reason when there is no upper limit on python version, then
recent versions of urllib3 cannot satisfy the dependencies, so we
ended up with version 1.22, which is incompatible with the nox safety
session. So adding a "<4.0" for python specifically for urllib3 allows
it to use the latest version 1.26