### PR TITLE
Try and fix permissions so Labeler action will work

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,6 +6,8 @@ on:
       - main
       - master
 
+permissions: write-all
+
 jobs:
   labeler:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is so that I don't have to give global write permissions for the entire repo